### PR TITLE
Add path prefix for gh-pages site

### DIFF
--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -8,6 +8,7 @@ module.exports = {
     permalink: "https://service-mesh-patterns.github.io/service-mesh-patterns/",
     image: "/images/service-mesh-pattern.png",
   },
+  pathPrefix: "/service-mesh-patterns",
   plugins: [
     "gatsby-plugin-react-helmet",
     "gatsby-plugin-sitemap",
@@ -16,7 +17,7 @@ module.exports = {
       options: {
         name: "manifest",
         short_name: "starter",
-        start_url: "/",
+        start_url: "/service-mesh-patterns/",
         background_color: "#3c494f",
         theme_color: "#00b39f",
         display: "minimal-ui",

--- a/site/package.json
+++ b/site/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "develop": "gatsby develop",
     "start": "gatsby develop",
-    "build": "gatsby build",
-    "serve": "gatsby serve",
+    "build": "gatsby build --prefix-paths",
+    "serve": "gatsby serve --prefix-paths",
     "clean": "gatsby clean && rimraf node_modules",
     "lint": "eslint --fix .",
     "checklint": "eslint .",


### PR DESCRIPTION
Signed-off-by: Nikhil-Ladha <nikhilladha1999@gmail.com>

**Description**
The domain provided by gh-pages has an extension of `service-mesh-patterns` i.e, the repo's name. And, to cover that a prefix has been added, which would compensate for the path extension while building the site.


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
