### PR TITLE
Button overlap removed with the nav 

### DIFF
--- a/site/src/sections/Chapters/chapters.style.js
+++ b/site/src/sections/Chapters/chapters.style.js
@@ -32,6 +32,7 @@ const ChaptersStyleWrapper = styled.main`
     
 
     .community-button {
+      z-index: 1;
       gap: 1rem;
       align-items: center;
       justify-content: center;


### PR DESCRIPTION
Signed-off-by: Kamal Nayan <geniusamansingh@gmail.com>

**Description**
Earlier:- 
![image](https://user-images.githubusercontent.com/95926324/192151393-7e58d7b2-3967-4264-8cb0-ef381bdad2d7.png)

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
